### PR TITLE
Corrected normal fusion result of Empress + Lovers

### DIFF
--- a/data4golden.js
+++ b/data4golden.js
@@ -280,7 +280,7 @@ const arcana2Combos = [
     {'source': ['Empress',     'Empress',     ], 'result': 'Empress'     },
     {'source': ['Empress',     'Emperor',     ], 'result': 'Moon'        },
     {'source': ['Empress',     'Heirophant',  ], 'result': 'Death'       },
-    {'source': ['Empress',     'Lovers',      ], 'result': 'Justice'     },
+    {'source': ['Empress',     'Lovers',      ], 'result': 'Hanged Man'  },
     {'source': ['Empress',     'Chariot',     ], 'result': 'Justice'     },
     {'source': ['Empress',     'Justice',     ], 'result': 'Magician'    },
     {'source': ['Empress',     'Hermit',      ], 'result': 'Magician'    },

--- a/data4golden.js
+++ b/data4golden.js
@@ -1,7 +1,5 @@
 // Derived from:
-//   http://www.gamefaqs.com/ps2/945498-shin-megami-tensei-persona-4/faqs/54981
-//   http://www.gamefaqs.com/ps2/945498-shin-megami-tensei-persona-4/faqs/54981
-//   http://db.gamefaqs.com//portable/vita//file/persona_4_golden_fusion.png
+//   https://aqiu384.github.io/megaten-fusion-tool/p4g/chart
 
 const personae = [
     {'arcana': 'Fool',        'level':  1, 'name': 'Izanagi',           },


### PR DESCRIPTION
Currently, Empress + Lovers on the calculator results in Justice. However, it's actually supposed to result in Hanged Man.
Examples below using Senri + Queen Mab:
<img width="837" height="267" alt="Justice" src="https://github.com/user-attachments/assets/aa6dd412-77ac-4bb0-97f8-4396dcb9739e" />
<img width="848" height="477" alt="Hanged Man" src="https://github.com/user-attachments/assets/1e085adc-3331-48f4-8a40-970aa08303e1" />
